### PR TITLE
Init windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,14 +134,14 @@ elseif(NOT MSVC)
     message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler. Suggested solution: update the pkg build-essential ")
 endif()
 
-if(MSVC)
-  add_definitions(-DNO_STRICT)
-  add_compile_options(/Zc:__cplusplus)
-  add_compile_options(/showIncludes)
-else()
+if(NOT MSVC)
   add_compile_options(-Wall)
   add_compile_options(-Wextra)
   add_compile_options(-Wno-unused-parameter)
+endif()
+
+if(MSVC)
+  add_compile_options(/Zc:__cplusplus)
 endif()
 
 # support indigo's ros_control - This can be removed upon EOL indigo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,13 +130,19 @@ if(COMPILER_SUPPORTS_CXX11)
     add_compile_options(-std=c++11)
 elseif(COMPILER_SUPPORTS_CXX0X)
     add_compile_options(-std=c++0x)
-else()
+elseif(NOT MSVC)
     message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler. Suggested solution: update the pkg build-essential ")
 endif()
 
-add_compile_options(-Wall)
-add_compile_options(-Wextra)
-add_compile_options(-Wno-unused-parameter)
+if(MSVC)
+  add_definitions(-DNO_STRICT)
+  add_compile_options(/Zc:__cplusplus)
+  add_compile_options(/showIncludes)
+else()
+  add_compile_options(-Wall)
+  add_compile_options(-Wextra)
+  add_compile_options(-Wno-unused-parameter)
+endif()
 
 # support indigo's ros_control - This can be removed upon EOL indigo
 if("${controller_manager_msgs_VERSION}" VERSION_LESS "0.10.0")
@@ -152,20 +158,7 @@ include_directories(include
 
 ## Declare a C++ library
 
-# Hardware Interface
-add_library(ur_hardware_interface
-  src/ros/hardware_interface.cpp
-  src/ros/controller.cpp)
-target_link_libraries(ur_hardware_interface
-  ${catkin_LIBRARIES}
-)
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(ur_modern_driver ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
+# Driver library
 set(${PROJECT_NAME}_SOURCES
     src/ros/action_server.cpp
     src/ros/mb_publisher.cpp
@@ -181,9 +174,36 @@ set(${PROJECT_NAME}_SOURCES
     src/ur/master_board.cpp
     src/ur/rt_state.cpp
     src/ur/messages.cpp
-    src/tcp_socket.cpp)
+    src/tcp_socket.cpp
+    src/bin_parser.cpp)
 
-add_executable(ur_driver ${${PROJECT_NAME}_SOURCES} src/ros_main.cpp)
+add_library(ur_driver_common
+  ${${PROJECT_NAME}_SOURCES}
+)
+target_link_libraries(ur_driver_common
+  ${catkin_LIBRARIES}
+  Ws2_32.lib
+)
+set_target_properties(ur_driver_common PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+
+# Hardware Interface
+add_library(ur_hardware_interface
+  src/ros/hardware_interface.cpp
+  src/ros/controller.cpp)
+target_link_libraries(ur_hardware_interface
+  ${catkin_LIBRARIES}
+  ur_driver_common
+)
+set_target_properties(ur_hardware_interface PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(ur_modern_driver ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+
+add_executable(ur_driver src/ros_main.cpp)
 
 ## Add cmake target dependencies of the executable
 ## same as for the library above
@@ -192,6 +212,7 @@ add_dependencies(ur_driver ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED
 ## Specify libraries to link a library or executable target against
 target_link_libraries(ur_driver
   ur_hardware_interface
+  ur_driver_common
   ${catkin_LIBRARIES}
  )
 
@@ -203,9 +224,12 @@ install(DIRECTORY launch/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
 install(DIRECTORY config/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/config)
 
 ## Mark executables and/or libraries for installation
-install(TARGETS ur_driver ur_hardware_interface
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+install(TARGETS ur_driver_common ur_hardware_interface
+  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+
+install(TARGETS ur_driver
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 ## Mark cpp header files for installation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,10 +140,6 @@ if(NOT MSVC)
   add_compile_options(-Wno-unused-parameter)
 endif()
 
-if(MSVC)
-  add_compile_options(/Zc:__cplusplus)
-endif()
-
 # support indigo's ros_control - This can be removed upon EOL indigo
 if("${controller_manager_msgs_VERSION}" VERSION_LESS "0.10.0")
     add_definitions(-DUR_ROS_CONTROL_INTERFACE_OLD_ROS_CONTROL)

--- a/include/ur_modern_driver/bin_parser.h
+++ b/include/ur_modern_driver/bin_parser.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <assert.h>
-#include <endian.h>
 #include <inttypes.h>
 #include <array>
 #include <bitset>
@@ -40,30 +39,12 @@ public:
   {
     return val;
   }
-  uint16_t decode(uint16_t val)
-  {
-    return be16toh(val);
-  }
-  uint32_t decode(uint32_t val)
-  {
-    return be32toh(val);
-  }
-  uint64_t decode(uint64_t val)
-  {
-    return be64toh(val);
-  }
-  int16_t decode(int16_t val)
-  {
-    return be16toh(val);
-  }
-  int32_t decode(int32_t val)
-  {
-    return be32toh(val);
-  }
-  int64_t decode(int64_t val)
-  {
-    return be64toh(val);
-  }
+  uint16_t decode(uint16_t val);
+  uint32_t decode(uint32_t val);
+  uint64_t decode(uint64_t val);
+  int16_t decode(int16_t val);
+  int32_t decode(int32_t val);
+  int64_t decode(int64_t val);
 
   template <typename T>
   T peek()

--- a/include/ur_modern_driver/portable_endian.h
+++ b/include/ur_modern_driver/portable_endian.h
@@ -1,0 +1,154 @@
+/**
+ * @file portable_endian.h
+ *
+ * Endianness conversion functions for a wide variety of systems,
+ * including Linux, FreeBSD, MacOS X and Windows.
+ */
+
+// "License": Public Domain
+// I, Mathias Panzenböck, place this file hereby into the public domain. Use it at your own risk for whatever you like.
+// In case there are jurisdictions that don't support putting things in the public domain you can also consider it to
+// be "dual licensed" under the BSD, MIT and Apache licenses, if you want to. This code is trivial anyway. Consider it
+// an example on how to get the endian conversion functions on different platforms.
+
+#ifndef PORTABLE_ENDIAN_H__
+#define PORTABLE_ENDIAN_H__
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+#define __WINDOWS__
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+#include <endian.h>
+#elif defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __PDP_ENDIAN PDP_ENDIAN
+#elif defined(__OpenBSD__)
+#include <sys/endian.h>
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#include <sys/endian.h>
+
+#define be16toh(x) betoh16(x)
+#define le16toh(x) letoh16(x)
+
+#define be32toh(x) betoh32(x)
+#define le32toh(x) letoh32(x)
+
+#define be64toh(x) betoh64(x)
+#define le64toh(x) letoh64(x)
+#elif defined(__WINDOWS__)
+#include <ws2tcpip.h>
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+#define htobe16(x) htons(x)
+#define htole16(x) (x)
+#define be16toh(x) ntohs(x)
+#define le16toh(x) (x)
+
+#define htobe32(x) htonl(x)
+#define htole32(x) (x)
+#define be32toh(x) ntohl(x)
+#define le32toh(x) (x)
+
+#define htobe64(x) htonll(x)
+#define htole64(x) (x)
+#define be64toh(x) ntohll(x)
+#define le64toh(x) (x)
+#elif BYTE_ORDER == BIG_ENDIAN
+/* That would be Xbox 360. */
+#define htobe16(x) (x)
+#define htole16(x) __builtin_bswap16(x)
+#define be16toh(x) (x)
+#define le16toh(x) __builtin_bswap16(x)
+
+#define htobe32(x) (x)
+#define htole32(x) __builtin_bswap32(x)
+#define be32toh(x) (x)
+#define le32toh(x) __builtin_bswap32(x)
+
+#define htobe64(x) (x)
+#define htole64(x) __builtin_bswap64(x)
+#define be64toh(x) (x)
+#define le64toh(x) __builtin_bswap64(x)
+#else
+#error byte order not supported
+#endif
+
+//#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __PDP_ENDIAN PDP_ENDIAN
+#else
+#error platform not supported
+#endif
+
+#ifdef __cplusplus
+
+#include <cstdint>
+#include <cstring>
+
+#else
+
+#include <stdint.h>
+#include <string.h>
+
+#endif
+
+// libcaer: define macros for floating-point conversions too.
+// Floats must be 4 bytes in size, so like a 32-bit integer, but their endianness
+// is undefined, so we use the 32bit conversion functions and memcpy() to do the
+// conversions safely (assumed integer and floating-point do have the same
+// endianness on the system, which is almost always true). For further details, see:
+// https://stackoverflow.com/questions/10620601/portable-serialisation-of-ieee754-floating-point-values
+static inline float htobeflt(float val) {
+	uint32_t rep;
+	memcpy(&rep, &val, sizeof(rep));
+	rep = htobe32(rep);
+	memcpy(&val, &rep, sizeof(rep));
+	return (val);
+}
+
+static inline float htoleflt(float val) {
+	uint32_t rep;
+	memcpy(&rep, &val, sizeof(rep));
+	rep = htole32(rep);
+	memcpy(&val, &rep, sizeof(rep));
+	return (val);
+}
+
+static inline float beflttoh(float val) {
+	uint32_t rep;
+	memcpy(&rep, &val, sizeof(rep));
+	rep = be32toh(rep);
+	memcpy(&val, &rep, sizeof(rep));
+	return (val);
+}
+
+static inline float leflttoh(float val) {
+	uint32_t rep;
+	memcpy(&rep, &val, sizeof(rep));
+	rep = le32toh(rep);
+	memcpy(&val, &rep, sizeof(rep));
+	return (val);
+}
+
+#endif /* PORTABLE_ENDIAN_H__ */

--- a/include/ur_modern_driver/tcp_socket.h
+++ b/include/ur_modern_driver/tcp_socket.h
@@ -1,10 +1,11 @@
 #pragma once
-#include <netdb.h>
-#include <sys/socket.h>
+
 #include <sys/types.h>
 #include <atomic>
 #include <mutex>
 #include <string>
+
+struct sockaddr;
 
 enum class SocketState
 {

--- a/include/ur_modern_driver/ur/server.h
+++ b/include/ur_modern_driver/ur/server.h
@@ -1,6 +1,4 @@
 #pragma once
-#include <netdb.h>
-#include <sys/socket.h>
 #include <sys/types.h>
 #include <atomic>
 #include <cstdlib>
@@ -9,6 +7,8 @@
 #include "ur_modern_driver/tcp_socket.h"
 
 #define MAX_SERVER_BUF_LEN 50
+
+struct sockaddr;
 
 class URServer : private TCPSocket
 {

--- a/include/ur_modern_driver/ur/stream.h
+++ b/include/ur_modern_driver/ur/stream.h
@@ -1,6 +1,5 @@
 #pragma once
-#include <netdb.h>
-#include <sys/socket.h>
+
 #include <sys/types.h>
 #include <atomic>
 #include <mutex>
@@ -16,10 +15,7 @@ private:
   std::mutex write_mutex_, read_mutex_;
 
 protected:
-  virtual bool open(int socket_fd, struct sockaddr* address, size_t address_len)
-  {
-    return ::connect(socket_fd, address, address_len) == 0;
-  }
+  virtual bool open(int socket_fd, struct sockaddr* address, size_t address_len);
 
 public:
   URStream(std::string& host, int port) : host_(host), port_(port)

--- a/src/bin_parser.cpp
+++ b/src/bin_parser.cpp
@@ -1,8 +1,4 @@
-#ifndef WIN32
-#include <endian.h>
-#else
 #include "ur_modern_driver/portable_endian.h"
-#endif
 #include "ur_modern_driver/bin_parser.h"
 
 uint16_t BinParser::decode(uint16_t val)

--- a/src/bin_parser.cpp
+++ b/src/bin_parser.cpp
@@ -1,0 +1,31 @@
+#ifndef WIN32
+#include <endian.h>
+#else
+#include "ur_modern_driver/portable_endian.h"
+#endif
+#include "ur_modern_driver/bin_parser.h"
+
+uint16_t BinParser::decode(uint16_t val)
+{
+    return be16toh(val);
+}
+uint32_t BinParser::decode(uint32_t val)
+{
+    return be32toh(val);
+}
+uint64_t BinParser::decode(uint64_t val)
+{
+    return be64toh(val);
+}
+int16_t BinParser::decode(int16_t val)
+{
+    return be16toh(val);
+}
+int32_t BinParser::decode(int32_t val)
+{
+    return be32toh(val);
+}
+int64_t BinParser::decode(int64_t val)
+{
+    return be64toh(val);
+}

--- a/src/ros/hardware_interface.cpp
+++ b/src/ros/hardware_interface.cpp
@@ -20,7 +20,7 @@ void JointInterface::update(RTShared &packet)
 const std::string WrenchInterface::INTERFACE_NAME = "hardware_interface::ForceTorqueSensorInterface";
 WrenchInterface::WrenchInterface(std::string tcp_link)
 {
-  registerHandle(hardware_interface::ForceTorqueSensorHandle("wrench", tcp_link, tcp_.begin(), tcp_.begin() + 3));
+  registerHandle(hardware_interface::ForceTorqueSensorHandle("wrench", tcp_link, &tcp_[0], &tcp_[3]));
 }
 
 void WrenchInterface::update(RTShared &packet)

--- a/src/ros/lowbandwidth_trajectory_follower.cpp
+++ b/src/ros/lowbandwidth_trajectory_follower.cpp
@@ -1,9 +1,5 @@
 #include "ur_modern_driver/ros/lowbandwidth_trajectory_follower.h"
-#ifndef WIN32
-#include <endian.h>
-#else
 #include <ur_modern_driver/portable_endian.h>
-#endif
 #include <cmath>
 #include <ros/ros.h>
 

--- a/src/ros/lowbandwidth_trajectory_follower.cpp
+++ b/src/ros/lowbandwidth_trajectory_follower.cpp
@@ -1,5 +1,9 @@
 #include "ur_modern_driver/ros/lowbandwidth_trajectory_follower.h"
+#ifndef WIN32
 #include <endian.h>
+#else
+#include <ur_modern_driver/portable_endian.h>
+#endif
 #include <cmath>
 #include <ros/ros.h>
 

--- a/src/ros/mb_publisher.cpp
+++ b/src/ros/mb_publisher.cpp
@@ -1,5 +1,13 @@
 #include "ur_modern_driver/ros/mb_publisher.h"
 
+#ifdef TRUE
+#undef TRUE
+#endif
+
+#ifdef FALSE
+#undef FALSE
+#endif
+
 inline void appendAnalog(std::vector<ur_msgs::Analog>& vec, double val, uint8_t pin)
 {
   ur_msgs::Analog ana;

--- a/src/ros/mb_publisher.cpp
+++ b/src/ros/mb_publisher.cpp
@@ -1,13 +1,5 @@
 #include "ur_modern_driver/ros/mb_publisher.h"
 
-#ifdef TRUE
-#undef TRUE
-#endif
-
-#ifdef FALSE
-#undef FALSE
-#endif
-
 inline void appendAnalog(std::vector<ur_msgs::Analog>& vec, double val, uint8_t pin)
 {
   ur_msgs::Analog ana;

--- a/src/ros/trajectory_follower.cpp
+++ b/src/ros/trajectory_follower.cpp
@@ -1,9 +1,5 @@
 #include "ur_modern_driver/ros/trajectory_follower.h"
-#ifndef WIN32
-#include <endian.h>
-#else
 #include <ur_modern_driver/portable_endian.h>
-#endif
 #include <cmath>
 #include <ros/ros.h>
 

--- a/src/ros/trajectory_follower.cpp
+++ b/src/ros/trajectory_follower.cpp
@@ -1,5 +1,9 @@
 #include "ur_modern_driver/ros/trajectory_follower.h"
+#ifndef WIN32
 #include <endian.h>
+#else
+#include <ur_modern_driver/portable_endian.h>
+#endif
 #include <cmath>
 #include <ros/ros.h>
 

--- a/src/tcp_socket.cpp
+++ b/src/tcp_socket.cpp
@@ -83,8 +83,6 @@ bool TCPSocket::setup(std::string &host, int port)
     setOptions(socket_fd_);
     state_ = SocketState::Connected;
     LOG_INFO("Connection established for %s:%d", host.c_str(), port);
-    auto ipaddress = getIP();
-    LOG_INFO("ip: %s", ipaddress.c_str());
   }
   return connected;
 }

--- a/src/tcp_socket.cpp
+++ b/src/tcp_socket.cpp
@@ -1,8 +1,4 @@
-#ifndef WIN32
-#include <endian.h>
-#else
 #include <ur_modern_driver/portable_endian.h>
-#endif
 #ifndef WIN32
 #include <arpa/inet.h>
 #include <netinet/tcp.h>

--- a/src/ur/server.cpp
+++ b/src/ur/server.cpp
@@ -71,7 +71,7 @@ bool URServer::accept()
     return false;
 
   struct sockaddr addr;
-  socklen_t addr_len = sizeof(addr);
+  socklen_t addr_len;
   int client_fd = -1;
 
   int retry = 0;

--- a/src/ur/server.cpp
+++ b/src/ur/server.cpp
@@ -75,17 +75,8 @@ bool URServer::accept()
   int client_fd = -1;
 
   int retry = 0;
-#ifndef INVALID_SOCKET
-#define INVALID_SOCKET -1
-#endif
-  while((client_fd = ::accept(getSocketFD(), &addr, &addr_len)) == INVALID_SOCKET){
-#ifdef WIN32
-    auto error_code = ::WSAGetLastError();
-#else
-    auto error_code = errno;
-#endif
-
-    LOG_ERROR("Accepting socket connection failed. (errno: %d)", error_code);
+  while((client_fd = ::accept(getSocketFD(), &addr, &addr_len)) == -1){
+    LOG_ERROR("Accepting socket connection failed. (errno: %d)", errno);
     if(retry++ >= 5)
       return false;
   }

--- a/src/ur/server.cpp
+++ b/src/ur/server.cpp
@@ -46,15 +46,8 @@ bool URServer::open(int socket_fd, struct sockaddr *address, size_t address_len)
 
 bool URServer::bind()
 {
-  std::string host;
-#ifdef WIN32
-  char hostname[MAX_PATH] = {0};
-  if (0 == gethostname(hostname, sizeof(hostname)))
-  {
-    host = hostname;
-  }
-#endif
-  bool res = TCPSocket::setup(host, port_);
+  std::string empty;
+  bool res = TCPSocket::setup(empty, port_);
 
   if (!res)
     return false;
@@ -71,7 +64,7 @@ bool URServer::accept()
     return false;
 
   struct sockaddr addr;
-  socklen_t addr_len;
+  socklen_t addr_len = sizeof(addr);
   int client_fd = -1;
 
   int retry = 0;

--- a/src/ur/stream.cpp
+++ b/src/ur/stream.cpp
@@ -1,8 +1,4 @@
-#ifndef WIN32
-#include <endian.h>
-#else
 #include <ur_modern_driver/portable_endian.h>
-#endif
 #ifndef WIN32
 #include <netinet/tcp.h>
 #include <unistd.h>

--- a/src/ur/stream.cpp
+++ b/src/ur/stream.cpp
@@ -1,10 +1,23 @@
+#ifndef WIN32
 #include <endian.h>
+#else
+#include <ur_modern_driver/portable_endian.h>
+#endif
+#ifndef WIN32
 #include <netinet/tcp.h>
 #include <unistd.h>
+#else
+#include <ws2tcpip.h>
+#endif
 #include <cstring>
 
 #include "ur_modern_driver/log.h"
 #include "ur_modern_driver/ur/stream.h"
+
+bool URStream::open(int socket_fd, struct sockaddr* address, size_t address_len)
+{
+  return ::connect(socket_fd, address, address_len) == 0;
+}
 
 bool URStream::write(const uint8_t* buf, size_t buf_len, size_t& written)
 {


### PR DESCRIPTION
* Refactor and add ur_driver_common shared library, which is because ur_hardware_interface.dll has a dependency on trajectory follower and it was in ur_driver.exe, but in turn, ur_driver also depends on ur_hardware_interface to be built. This cyclic dependencies seems not to be a problem for GNU linker but it break the MSVC build, so refactor some code into a common dll to solve this problem for Windows platform.

* Add portable_endian.h since MSVC and Windows SDK doesn't have endian.h. (Credit to https://gist.github.com/panzi/6856583)

* In TCPSocket::setup, explicitly define we would like to get IPv4 address since that's also the stack UR controller box is using. Otherwise, in Windows, it will return IPv6 by default.

* In URServer::accept, initialize addrlen so it won't throw WSAEFAULT in ::accept.